### PR TITLE
Job tags persist on jobs list page

### DIFF
--- a/website/components/Buttons/TagJobButton.tsx
+++ b/website/components/Buttons/TagJobButton.tsx
@@ -5,15 +5,13 @@ import React from "react";
 import BookmarkBorderIcon from "@mui/icons-material/BookmarkBorder";
 import BookmarkIcon from "@mui/icons-material/Bookmark";
 import { JobTagsMenu } from "../JobTags/Menu/JobTagsMenu";
-import { ITag } from "src/lib/requests/ExtensionRequests";
 import { useTagJobButton } from "src/lib/hooks/useTagJobButton";
 
 interface ITagJobButton {
-  selectedTags: ITag[];
-  tagsToSelect: ITag[];
+  jobID: string;
 }
 export const TagJobButton = (props: ITagJobButton) => {
-  const { selectedTags, tagsToSelect } = props;
+  const { jobID } = props;
   const {
     hovering,
     setHovering,
@@ -23,19 +21,7 @@ export const TagJobButton = (props: ITagJobButton) => {
     buttonText,
     hoveringText,
     iconColor,
-    setSelectedTags,
-    selectedTags: userSelectedTags,
-    setUserTagsToSelect,
-    userTagsToSelect,
-  } = useTagJobButton(selectedTags, tagsToSelect);
-
-  const onSetSelectedTags = (tags: ITag[]) => {
-    setSelectedTags(tags);
-  };
-
-  const onSetTagsToSelect = (tags: ITag[]) => {
-    setUserTagsToSelect(tags);
-  };
+  } = useTagJobButton(jobID);
 
   return (
     <MainWrapper>
@@ -61,13 +47,10 @@ export const TagJobButton = (props: ITagJobButton) => {
       {menuOpen ? (
         <TagsMenuWrapper>
           <JobTagsMenu
-            selectedTags={userSelectedTags}
-            tagsToSelect={userTagsToSelect}
+            jobID={jobID}
             onOutsideClick={() => {
               setMenuOpen(false);
             }}
-            onSetSelectedTags={onSetSelectedTags}
-            onSetTagsToSelect={onSetTagsToSelect}
           />
         </TagsMenuWrapper>
       ) : null}

--- a/website/components/Buttons/TagJobIconButton.tsx
+++ b/website/components/Buttons/TagJobIconButton.tsx
@@ -4,32 +4,21 @@ import React from "react";
 import BookmarkIcon from "@mui/icons-material/Bookmark";
 import BookmarkOutlineIcon from "@mui/icons-material/BookmarkBorder";
 import { JobTagsMenu } from "../JobTags/Menu/JobTagsMenu";
-import { ITag } from "src/lib/requests/ExtensionRequests";
 import { useTagJobButton } from "src/lib/hooks/useTagJobButton";
 import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
 
-interface ITagJobButton {
-  selectedTags: ITag[];
+interface ITagJobIconButton {
+  jobID: string;
 }
-export const TagJobIconButton = (props: ITagJobButton) => {
-  const { selectedTags } = props;
+export const TagJobIconButton = (props: ITagJobIconButton) => {
+  const { jobID } = props;
   const {
     menuOpen,
     setMenuOpen,
-    setSelectedTags,
     selectedTags: userSelectedTags,
-    setUserTagsToSelect,
-    userTagsToSelect,
-  } = useTagJobButton(selectedTags);
-
-  const onSetSelectedTags = (tags: ITag[]) => {
-    setSelectedTags(tags);
-  };
-
-  const onSetTagsToSelect = (tags: ITag[]) => {
-    setUserTagsToSelect(tags);
-  };
+    iconColor,
+  } = useTagJobButton(jobID);
 
   return (
     <MainWrapper>
@@ -49,7 +38,7 @@ export const TagJobIconButton = (props: ITagJobButton) => {
           }}
         >
           <InnerIcon>
-            <StyledBookmarkIcon bgcolor={userSelectedTags[0].color} />
+            <StyledBookmarkIcon bgcolor={iconColor} />
             <StyledButtonLabel>{userSelectedTags.length}</StyledButtonLabel>
           </InnerIcon>
         </IconButton>
@@ -58,14 +47,10 @@ export const TagJobIconButton = (props: ITagJobButton) => {
       {menuOpen ? (
         <TagsMenuWrapper>
           <JobTagsMenu
-            selectedTags={userSelectedTags}
-            tagsToSelect={userTagsToSelect}
             onOutsideClick={() => {
-              setUserTagsToSelect(undefined);
               setMenuOpen(false);
             }}
-            onSetSelectedTags={onSetSelectedTags}
-            onSetTagsToSelect={onSetTagsToSelect}
+            jobID={jobID}
           />
         </TagsMenuWrapper>
       ) : null}

--- a/website/components/JobTags/Menu/JobTagsMenu.tsx
+++ b/website/components/JobTags/Menu/JobTagsMenu.tsx
@@ -21,24 +21,15 @@ import { EditTagModal } from "src/components/Modals/variants/EditTagModal";
 import { IconColorWrapper } from "src/components/icons/ColorWrapper";
 
 interface ITagsMenu {
-  selectedTags?: ITag[];
-  tagsToSelect?: ITag[];
   onOutsideClick: () => void;
-  onSetSelectedTags: (tags: ITag[]) => void;
-  onSetTagsToSelect: (tags: ITag[]) => void;
+  jobID: string;
 }
 export const JobTagsMenu = (props: ITagsMenu) => {
-  const {
-    selectedTags: tagsSelected,
-    tagsToSelect: selectableTags,
-    onOutsideClick,
-    onSetSelectedTags,
-    onSetTagsToSelect,
-  } = props;
+  const { onOutsideClick, jobID } = props;
   const {
     loading,
-    selectedTags,
-    tagsToSelect,
+    displaySelectedTags,
+    displayTagsToSelect,
     selectTag,
     removeTag,
     inputVal,
@@ -46,18 +37,9 @@ export const JobTagsMenu = (props: ITagsMenu) => {
     canCreateNew,
     onSubmit,
     error,
-    editTag,
     setEditTag,
     isEditModalOpen,
-    onPatchTag,
-    onDeleteTag,
-  } = useTagsMenu(
-    123,
-    onSetSelectedTags,
-    onSetTagsToSelect,
-    tagsSelected,
-    selectableTags
-  );
+  } = useTagsMenu(jobID);
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     onSubmit();
@@ -93,7 +75,7 @@ export const JobTagsMenu = (props: ITagsMenu) => {
   const renderSelectedChips = () => (
     <>
       <ChipsWrapper>
-        {selectedTags.map(tag => (
+        {displaySelectedTags.map(tag => (
           <StyledChip
             key={tag.label}
             bgcolor={tag.color}
@@ -108,14 +90,14 @@ export const JobTagsMenu = (props: ITagsMenu) => {
           />
         ))}
       </ChipsWrapper>
-      {selectedTags.length > 0 ? <Spacer height={8} /> : null}
+      {displaySelectedTags.length > 0 ? <Spacer height={8} /> : null}
     </>
   );
 
   const renderMenu = () => (
     <TagsListWrapper>
       <StyledMenuList>
-        {tagsToSelect.map(tag => (
+        {displayTagsToSelect.map(tag => (
           <StyledMenuItem key={tag.label}>
             <StyledListItemText
               bgcolor={tag.color}
@@ -136,7 +118,7 @@ export const JobTagsMenu = (props: ITagsMenu) => {
             </ListItemIcon>
             <ListItemIcon
               onClick={() => {
-                setEditTag(tag);
+                setEditTag(tag.label);
               }}
             >
               <MoreIconWrapper>
@@ -179,18 +161,7 @@ export const JobTagsMenu = (props: ITagsMenu) => {
 
   return (
     <>
-      {editTag ? (
-        <EditTagModal
-          tag={editTag}
-          isOpen={isEditModalOpen}
-          onClose={() => {
-            setEditTag(undefined);
-          }}
-          allTags={[...selectedTags, ...tagsToSelect]}
-          onPatchTag={onPatchTag}
-          onDeleteTag={onDeleteTag}
-        />
-      ) : null}
+      <EditTagModal />
       <TagsWrapper ref={ref}>
         <TagsHeader>
           {renderSelectedChips()}
@@ -204,7 +175,7 @@ export const JobTagsMenu = (props: ITagsMenu) => {
 
 interface IInnerChipContent {
   tag: ITag;
-  onSetEditTag: (tag: ITag) => void;
+  onSetEditTag: (label: string) => void;
 }
 const renderInnerChipContent = (props: IInnerChipContent) => {
   const { tag, onSetEditTag } = props;
@@ -214,7 +185,7 @@ const renderInnerChipContent = (props: IInnerChipContent) => {
       <InnerChipContentWrapper>
         <IconButton
           onClick={() => {
-            onSetEditTag(tag);
+            onSetEditTag(tag.label);
           }}
         >
           <EditIcon />

--- a/website/components/JobsDataGrid/JobsDataGrid.tsx
+++ b/website/components/JobsDataGrid/JobsDataGrid.tsx
@@ -8,7 +8,6 @@ import {
 import { JobsPageRowData } from "src/lib/jobsList/jobsList";
 import { BackgroundColor } from "src/styles/color";
 import Paper from "@mui/material/Paper";
-import { useState } from "react";
 import {
   LocationText,
   Orientation,
@@ -22,6 +21,7 @@ import AttachMoneyIcon from "@mui/icons-material/AttachMoney";
 import StarIcon from "@mui/icons-material/Star";
 import SearchIcon from "@mui/icons-material/Search";
 import { DeadlineCell } from "./components/DeadlineCell";
+import { useJobsDataGrid } from "src/lib/hooks/UseJobsDataGrid";
 
 interface IJobsDataGrid {
   jobKeywords: { [key: string]: string[] };
@@ -31,8 +31,9 @@ interface IJobsDataGrid {
 }
 export const JobsDataGrid = (props: IJobsDataGrid) => {
   const { jobKeywords, jobs, loading, companyLogos } = props;
+  const { pageSize, setPageSize } = useJobsDataGrid();
 
-  const [pageSize, setPageSize] = useState(10);
+  const isLoading = loading;
 
   const headerComponent = (
     headerData: GridColumnHeaderParams<any, JobsPageRowData>
@@ -180,9 +181,7 @@ export const JobsDataGrid = (props: IJobsDataGrid) => {
       headerAlign: "center",
       renderHeader: headerComponent,
       sortable: false,
-      renderCell: rowData => (
-        <ActionsCell jobID={rowData.id.toString()} selectedTags={[]} />
-      ),
+      renderCell: rowData => <ActionsCell jobID={rowData.id.toString()} />,
     },
   ];
 
@@ -196,7 +195,7 @@ export const JobsDataGrid = (props: IJobsDataGrid) => {
           rows={jobs}
           columns={columns}
           pageSize={pageSize}
-          loading={loading}
+          loading={isLoading}
           disableColumnMenu
           onPageSizeChange={(newPageSize: number) => setPageSize(newPageSize)}
           rowsPerPageOptions={[10, 25, 100]}
@@ -242,7 +241,9 @@ const PillsWrapper = styled.div`
 const Main = styled(Paper).attrs({
   elevation: 0,
 })`
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: visible;
+  position: relative;
 `;
 const InnerPaper = styled.div`
   width: calc(100% + 76px);

--- a/website/components/JobsDataGrid/components/ActionsCell.tsx
+++ b/website/components/JobsDataGrid/components/ActionsCell.tsx
@@ -1,4 +1,3 @@
-import { ITag } from "src/lib/requests/ExtensionRequests";
 import { BackgroundColor } from "src/styles/color";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import styled from "styled-components";
@@ -8,14 +7,13 @@ import Tooltip from "@mui/material/Tooltip";
 
 interface IActionsCell {
   jobID: string;
-  selectedTags: ITag[];
 }
 
 export const ActionsCell = (props: IActionsCell) => {
-  const { jobID, selectedTags } = props;
+  const { jobID } = props;
   return (
     <ActionsWrapper>
-      <TagJobIconButton selectedTags={selectedTags} />
+      <TagJobIconButton jobID={jobID} />
       <Tooltip title="Open in Waterloo Works" arrow placement="top">
         <StyledA
           href={`https://waterlooworks.uwaterloo.ca/myAccount/co-op/coop-postings.htm?ck_jobid=${jobID}`}

--- a/website/components/Modals/variants/EditTagModal.tsx
+++ b/website/components/Modals/variants/EditTagModal.tsx
@@ -2,7 +2,6 @@ import Typography from "@mui/material/Typography";
 import { BaseModal } from "../BaseModal";
 import { Spacer } from "src/components/Spacer/Spacer";
 import styled from "styled-components";
-import { ITag } from "src/lib/requests/ExtensionRequests";
 import Chip from "@mui/material/Chip";
 import BookmarkIcon from "@mui/icons-material/Bookmark";
 import ColorPicker from "src/components/ColorPicker/ColorPicker";
@@ -17,24 +16,7 @@ import { convertToCamelCase } from "src/lib/strings/convertStrings";
 import { IconColorWrapper } from "src/components/icons/ColorWrapper";
 import { useEditTagModal } from "src/lib/hooks/useEditTagModal";
 
-interface IUploadDomainModal {
-  isOpen: boolean;
-  onClose: () => void;
-  tag: ITag;
-  allTags: ITag[];
-  onPatchTag: (newTag: ITag) => void;
-  onDeleteTag: () => void;
-}
-
-export const EditTagModal = (props: IUploadDomainModal) => {
-  const {
-    isOpen,
-    onClose,
-    tag: initTag,
-    allTags,
-    onPatchTag,
-    onDeleteTag,
-  } = props;
+export const EditTagModal = () => {
   const {
     deleteMode,
     setDeleteMode,
@@ -46,7 +28,14 @@ export const EditTagModal = (props: IUploadDomainModal) => {
     colors,
     tagExistsError,
     tag,
-  } = useEditTagModal(isOpen, initTag, allTags, onPatchTag, onDeleteTag);
+    initTag,
+    isOpen,
+    onClose,
+  } = useEditTagModal();
+
+  if (!tag) {
+    return;
+  }
 
   const renderDeleteModeButtons = () => {
     if (!deleteMode) {
@@ -116,7 +105,7 @@ export const EditTagModal = (props: IUploadDomainModal) => {
 
   const renderTitle = () => (
     <Typography align="center" variant="h5">
-      <b>{`Edit "${initTag.label}" Tag`}</b>
+      <b>{`Edit "${initTag}" Tag`}</b>
     </Typography>
   );
 
@@ -153,7 +142,7 @@ export const EditTagModal = (props: IUploadDomainModal) => {
       <TextField
         variant="outlined"
         size="small"
-        defaultValue={tag.label}
+        value={tag.label}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           setTag({
             color: tag.color,
@@ -164,10 +153,9 @@ export const EditTagModal = (props: IUploadDomainModal) => {
     </Edit>
   );
   const renderError = () => (
-    <Typography
-      color={tagExistsError ? "red" : "white"}
-      align="center"
-    >{`Tag "${tag.label}" already exists`}</Typography>
+    <Typography color={tagExistsError ? "red" : "white"} align="center">
+      {!tag.label ? "Type in a value" : `Tag "${tag.label}" already exists`}
+    </Typography>
   );
   return (
     <BaseModal

--- a/website/lib/context/jobTags/JobTagsContext.tsx
+++ b/website/lib/context/jobTags/JobTagsContext.tsx
@@ -1,0 +1,24 @@
+import { createContext } from "react";
+import {
+  AllTagsObject,
+  IJobToTags,
+  ITag,
+} from "src/lib/requests/ExtensionRequests";
+
+export interface JobTagsContextType {
+  allTags: AllTagsObject;
+  jobToTags: IJobToTags;
+  isLoading: boolean;
+  editTag?: string;
+  setEditTag: (label: string) => void;
+  onSelectTag: (jobID: string, label: string) => void;
+  onRemoveTag: (jobID: string, label: string) => void;
+  onCreateNewTagAndAddToJob: (jobID: string, tag: ITag) => void;
+  onPatchTag: (newTag: ITag) => void;
+  onDeleteTag: () => void;
+  closeEditModal: () => void;
+}
+
+export const JobTagsContext = createContext<JobTagsContextType | undefined>(
+  undefined
+);

--- a/website/lib/context/jobTags/JobTagsProvider.tsx
+++ b/website/lib/context/jobTags/JobTagsProvider.tsx
@@ -1,0 +1,139 @@
+import React, { useState, useEffect } from "react";
+import {
+  JobTagsContextType,
+  JobTagsContext,
+} from "src/lib/context/jobTags/JobTagsContext";
+import {
+  AllTagsObject,
+  ExtensionRequests,
+  IJobToTags,
+  ITag,
+} from "src/lib/requests/ExtensionRequests";
+
+interface IJobsTagsProvider {
+  children: React.ReactNode;
+}
+
+//TODO: add extention requet calls
+export const JobTagsProvider = ({ children }: IJobsTagsProvider) => {
+  const [allTags, setAllTags] = useState<AllTagsObject>({});
+  const [jobToTags, setJobsToTags] = useState<IJobToTags>({});
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [editTag, setEditTagState] = useState<string | undefined>();
+
+  useEffect(() => {
+    const fire = async () => {
+      const [allTags, jobsToTags] = await Promise.all([
+        ExtensionRequests.getAllTags(),
+        ExtensionRequests.getAllJobsToTags(),
+      ]);
+      setAllTags(allTags);
+      setJobsToTags(jobsToTags);
+      setIsLoading(false);
+    };
+
+    fire();
+  }, []);
+
+  const onSelectTag = (jobID: string, tag: string) => {
+    setJobsToTags({
+      ...jobToTags,
+      [jobID]: [...(jobToTags[jobID] ?? []), tag],
+    });
+    ExtensionRequests.onSelectTag(jobID, tag);
+  };
+
+  const onRemoveTag = (jobID: string, label: string) => {
+    setJobsToTags({
+      ...jobToTags,
+      [jobID]: [...jobToTags[jobID]].filter(x => x !== label),
+    });
+    ExtensionRequests.onRemoveTag(jobID, label);
+  };
+
+  const onCreateNewTagAndAddToJob = (jobID: string, tag: ITag) => {
+    setAllTags({
+      ...allTags,
+      [tag.label]: {
+        color: tag.color,
+      },
+    });
+    setJobsToTags({
+      ...jobToTags,
+      [jobID]: [...(jobToTags[jobID] ?? []), tag.label],
+    });
+    ExtensionRequests.createNewTagAndAddToJob(jobID, tag);
+  };
+
+  const setEditTag = (label: string) => {
+    setEditTagState(label);
+  };
+
+  const closeEditModal = () => {
+    setEditTagState(undefined);
+  };
+
+  const onPatchTag = (newTag: ITag) => {
+    if (!editTag) {
+      return;
+    }
+    const newAllTags = { ...allTags };
+    delete newAllTags[editTag];
+    setAllTags({
+      ...newAllTags,
+      [newTag.label]: {
+        color: newTag.color,
+      },
+    });
+    const newJobToTags = { ...jobToTags };
+    Object.keys(jobToTags).forEach(jobID => {
+      newJobToTags[jobID] = [
+        ...newJobToTags[jobID].map(label => {
+          if (label === editTag) {
+            return newTag.label;
+          }
+          return label;
+        }),
+      ];
+    });
+    setJobsToTags(newJobToTags);
+    ExtensionRequests.patchTag(editTag, newTag);
+    setEditTagState(undefined);
+  };
+
+  const onDeleteTag = () => {
+    if (!editTag) {
+      return;
+    }
+    const newAllTags = { ...allTags };
+    delete newAllTags[editTag];
+    setAllTags({
+      ...newAllTags,
+    });
+    const newJobToTags = { ...jobToTags };
+    Object.keys(jobToTags).forEach(jobID => {
+      newJobToTags[jobID] = [...newJobToTags[jobID].filter(x => x !== editTag)];
+    });
+    setJobsToTags(newJobToTags);
+    ExtensionRequests.deleteTag(editTag);
+    setEditTagState(undefined);
+  };
+
+  const value: JobTagsContextType = {
+    closeEditModal,
+    onDeleteTag,
+    allTags,
+    jobToTags,
+    isLoading,
+    editTag,
+    setEditTag,
+    onSelectTag,
+    onRemoveTag,
+    onCreateNewTagAndAddToJob,
+    onPatchTag,
+  };
+
+  return (
+    <JobTagsContext.Provider value={value}>{children}</JobTagsContext.Provider>
+  );
+};

--- a/website/lib/hooks/UseJobsDataGrid.ts
+++ b/website/lib/hooks/UseJobsDataGrid.ts
@@ -1,0 +1,10 @@
+import { useState } from "react";
+
+export const useJobsDataGrid = () => {
+  const [pageSize, setPageSize] = useState(10);
+
+  return {
+    pageSize,
+    setPageSize,
+  };
+};

--- a/website/lib/hooks/useJobsList.ts
+++ b/website/lib/hooks/useJobsList.ts
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
-import { JobsPageRowData } from "../jobsList/jobsList";
-import { useExtensionData } from "../extension/hooks/useExtensionData";
+import { useEffect, useState, useContext } from "react";
+import { JobsPageRowData } from "src/lib/jobsList/jobsList";
+import { useExtensionData } from "src/lib/extension/hooks/useExtensionData";
 import { ISearchChip } from "src/components/SearchBar/SearchBarJobsList";
 import {
   DAYS_TO_STALE_DATA,
@@ -15,6 +15,7 @@ import {
   Requests,
 } from "src/lib/requests/Requests";
 import { getSearchTypeField, SearchTypes } from "src/lib/search/Search";
+import { JobTagsContext } from "../context/jobTags/JobTagsContext";
 
 export const useJobsList = () => {
   const {
@@ -39,10 +40,13 @@ export const useJobsList = () => {
     {}
   );
   const [numActiveChips, setNumActiveChips] = useState<number>(0);
-
   const [logos, setLogos] = useState<IGetCompanyLogosResponse | undefined>();
-
   const dateScraped = extensionData[LocalStorageMetadataKeys.SCRAPE_AT];
+  const jobTagsContext = useContext(JobTagsContext);
+  if (!jobTagsContext) {
+    throw new Error("JobTagsProvider not wrapped");
+  }
+  const { isLoading: isJobTagsLoading } = jobTagsContext;
 
   useEffect(() => {
     const fire = async () => {
@@ -139,7 +143,7 @@ export const useJobsList = () => {
     setDisplayJobs(newJobs);
   }, [jobsList, searchIndex, searchChips, numActiveChips]);
 
-  const isLoading = !isDataReady;
+  const isLoading = !isDataReady || isJobTagsLoading;
 
   return {
     displayJobs,

--- a/website/lib/hooks/useTagJobButton.ts
+++ b/website/lib/hooks/useTagJobButton.ts
@@ -1,24 +1,26 @@
-import { useState } from "react";
-import { ITag } from "src/lib/requests/ExtensionRequests";
+import { useState, useContext } from "react";
+import { JobTagsContext } from "src/lib/context/jobTags/JobTagsContext";
 
-export const useTagJobButton = (
-  initSelectedTags: ITag[],
-  tagsToSelect?: ITag[]
-) => {
+export const useTagJobButton = (jobID: string) => {
   const [hovering, setHovering] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
-  const [selectedTags, setSelectedTags] = useState(initSelectedTags);
-  const [userTagsToSelect, setUserTagsToSelect] = useState(tagsToSelect);
+  const jobTagsContext = useContext(JobTagsContext);
+  if (!jobTagsContext) {
+    throw new Error("JobTagsProvider not wrapped");
+  }
+  const { jobToTags, allTags } = jobTagsContext;
+  const selectedTags = jobToTags[jobID] ?? [];
   const hasTagsSelected = selectedTags.length > 0;
   const selected = hasTagsSelected;
+  const firstTagLabel = selectedTags[0];
   const hasTagsButtonText = hasTagsSelected
     ? selectedTags.length > 1
-      ? `${selectedTags[0].label} +${selectedTags.length - 1}`
-      : selectedTags[0].label
+      ? `${firstTagLabel} +${selectedTags.length - 1}`
+      : firstTagLabel
     : "";
   const buttonText = hasTagsSelected ? hasTagsButtonText : "Tag";
   const hoveringText = hasTagsSelected ? "Edit Tags" : "Add Tags";
-  const iconColor = hasTagsSelected ? selectedTags[0].color : "white";
+  const iconColor = hasTagsSelected ? allTags[firstTagLabel]?.color : "white";
 
   return {
     hovering,
@@ -30,8 +32,5 @@ export const useTagJobButton = (
     hoveringText,
     iconColor,
     selectedTags,
-    setSelectedTags,
-    userTagsToSelect,
-    setUserTagsToSelect,
   };
 };

--- a/website/lib/requests/ExtensionRequests.ts
+++ b/website/lib/requests/ExtensionRequests.ts
@@ -9,43 +9,63 @@ function delay(ms: number): Promise<void> {
   });
 }
 
-const dummyTags: ITag[] = [
-  {
-    label: "Ambitious",
+const dummyTags: AllTagsObject = {
+  Ambitious: {
     color: Color.ambitious,
   },
-  {
-    label: "Possible",
+  Possible: {
     color: Color.possible,
   },
-  {
-    label: "Safe",
+  Safe: {
     color: Color.safe,
   },
-];
+};
 
 //TODO: End of code to remove
 //Tag labels are unique, so we can use as an ID
-export interface ITag {
+interface ITagProps {
   color: string;
+}
+
+export interface ITag extends ITagProps {
   label: string;
 }
+
+export interface AllTagsObject {
+  [label: string]: ITagProps;
+}
+
+export interface IJobToTags {
+  [jobID: string]: string[];
+}
 export class ExtensionRequests {
-  static async getAllTags(): Promise<ITag[]> {
+  static async getAllTags(): Promise<AllTagsObject> {
     await delay(500);
     return dummyTags;
   }
 
-  //gets the selected tags of a certain jobid
-  static async getSelectedTags(jobID: number): Promise<ITag[]> {
-    console.log(jobID);
+  static async getAllJobsToTags(): Promise<IJobToTags> {
     await delay(500);
-    return [];
+    return { "311699": ["Ambitious"] };
+  }
+
+  //Adds a tag to a jobID
+  static async onSelectTag(jobID: string, tag: string): Promise<undefined> {
+    await delay(500);
+    console.log(jobID, tag);
+    return;
+  }
+
+  //Removes a tag from a jobID (tag still exists)
+  static async onRemoveTag(jobID: string, label: string): Promise<undefined> {
+    await delay(500);
+    console.log(jobID, label);
+    return;
   }
 
   //Creates a new tag and adds that tag to the jobID
   static async createNewTagAndAddToJob(
-    jobID: number,
+    jobID: string,
     tag: ITag
   ): Promise<undefined> {
     console.log(jobID, tag);
@@ -53,8 +73,8 @@ export class ExtensionRequests {
     return;
   }
 
-  static async patchTag(name: string, color: string): Promise<undefined> {
-    console.log(name, color);
+  static async patchTag(oldTagID: string, newTag: ITag): Promise<undefined> {
+    console.log(oldTagID, newTag);
     await delay(500);
     return;
   }

--- a/website/package.json
+++ b/website/package.json
@@ -43,7 +43,7 @@
     "@types/lunr": "^2.3.4",
     "@types/next-auth": "^3.15.0",
     "@types/opentype.js": "^1.3.3",
-    "@types/react": "17.0.19",
+    "@types/react": "^18.2.0",
     "@types/react-color": "^3.0.5",
     "@types/react-dropzone": "^4.2.0",
     "@types/react-html-parser": "^2.0.2",

--- a/website/pages/_app.tsx
+++ b/website/pages/_app.tsx
@@ -2,6 +2,7 @@ import type { AppProps } from "next/app";
 import React from "react";
 import { createTheme, ThemeProvider, CssBaseline } from "@mui/material";
 import Head from "next/head";
+import { JobTagsProvider } from "src/lib/context/jobTags/JobTagsProvider";
 
 const theme = createTheme({
   typography: {
@@ -33,7 +34,9 @@ function MyApp({ Component, pageProps: { ...pageProps } }: AppProps) {
       </Head>
       <Provider theme={theme}>
         <CssBaseline />
-        <AnyComponent {...pageProps} />
+        <JobTagsProvider>
+          <AnyComponent {...pageProps} />
+        </JobTagsProvider>
       </Provider>
     </>
   );

--- a/website/pages/jobs/[jobID].tsx
+++ b/website/pages/jobs/[jobID].tsx
@@ -35,7 +35,7 @@ import IconButton from "@mui/material/IconButton";
 import { JobInfoFieldsCoop } from "src/lib/extension/jobKeys";
 const SpecificJobPage = () => {
   const router = useRouter();
-  const jobID = router.query.jobID;
+  const jobID = router.query.jobID as string | undefined;
   const {
     imageURL,
     companyInfo,
@@ -47,9 +47,7 @@ const SpecificJobPage = () => {
     techIcons,
     companyURL,
     onClearbitData,
-    selectedTags,
-    tagsToSelect,
-  } = useJobPage(jobID as string | undefined);
+  } = useJobPage(jobID);
   const [submitDomainModal, setSubmitDomainModal] = useState(false);
   useEffect(() => {
     if (!job) {
@@ -59,7 +57,7 @@ const SpecificJobPage = () => {
   }, [job]);
 
   const renderCompanyHeader = () => {
-    if (isLoading) {
+    if (isLoading || !jobID) {
       return (
         <CompanyHeaderWrapper>
           <div>
@@ -98,10 +96,7 @@ const SpecificJobPage = () => {
               <PrimaryButton>Apply</PrimaryButton>
             </a>
             <Spacer width={8} />
-            <TagJobButton
-              selectedTags={selectedTags}
-              tagsToSelect={tagsToSelect}
-            />
+            <TagJobButton jobID={jobID} />
           </ButtonsWrapper>
         </div>
         <JobRatingCard

--- a/website/pages/jobs/index.tsx
+++ b/website/pages/jobs/index.tsx
@@ -41,13 +41,14 @@ export default function JobsListPage() {
             Jobs List
           </Typography>
           <Spacer height={16} />
-          <Typography>{numJobs} Listings</Typography>
+          {!isLoading ? <Typography>{numJobs} Listings</Typography> : null}
+
           <Spacer height={16} />
           {!!dataAgeMessage && (
-            <Typography>
-              {dataAgeMessage}
-              {isStale ? <WarningIcon width={16} /> : <CheckIcon width={16} />}
-            </Typography>
+            <StatusWrapper>
+              <Typography>{dataAgeMessage} </Typography>
+              {isStale ? <WarningIcon width={24} /> : <CheckIcon width={24} />}
+            </StatusWrapper>
           )}
           <Spacer height={32} />
         </MainWrapper>
@@ -88,4 +89,11 @@ const WaterWrapper = styled.div`
   width: 100%;
   background-color: ${BackgroundColor.dark};
   min-height: 100vh;
+`;
+
+const StatusWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  justify-content: center;
 `;

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1477,10 +1477,10 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@17.0.19":
-  version "17.0.19"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.19.tgz#8f2a85e8180a43b57966b237d26a29481dacc991"
-  integrity sha512-sX1HisdB1/ZESixMTGnMxH9TDe8Sk709734fEQZzCV/4lSu9kJCPbo2PbTRoZM+53Pp0P10hYVyReUueGwUi4A==
+"@types/react@18.2.0":
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.0.tgz#15cda145354accfc09a18d2f2305f9fc099ada21"
+  integrity sha512-0FLj93y5USLHdnhIhABk83rm8XEGA7kH3cr+YUlvxoUGp1xNt/DINUMvqPxLyOQMzLmZe8i4RTHbvb8MC7NmrA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
Makes the jobTags a global using React's context api. This so that there is less props being passed between components and so that the UI state for the job tags persists when going to a new page on the jobs list page