### PR TITLE
Fix extension data fetch

### DIFF
--- a/website/components/JobsDataGrid/components/JobTitleCell.tsx
+++ b/website/components/JobsDataGrid/components/JobTitleCell.tsx
@@ -1,7 +1,6 @@
 import { Color } from "src/styles/color";
 import styled from "styled-components";
 import Typography from "@mui/material/Typography";
-import Link from "next/link";
 
 interface IJobTitleCell {
   company: string;
@@ -14,11 +13,11 @@ export const JobTitleCell = (props: IJobTitleCell) => {
   const { company, jobName, jobID, imageURL } = props;
   return (
     <JobTitleCellWrapper>
-      <StyledLink href={`/jobs/${jobID}`}>
+      <StyledLink href={`/jobs/${jobID}`} target="_blank">
         <CompanyProfilePic imageURL={imageURL} />
       </StyledLink>
       <CompanyDetailsWrapper>
-        <StyledLink href={`/jobs/${jobID}`}>
+        <StyledLink href={`/jobs/${jobID}`} target="_blank">
           <Typography>{jobName}</Typography>
         </StyledLink>
         <Typography variant="caption">{company}</Typography>
@@ -55,6 +54,6 @@ const CompanyDetailsWrapper = styled.div`
   flex-direction: column;
   justify-content: center;
 `;
-const StyledLink = styled(Link as any)`
+const StyledLink = styled.a`
   color: ${Color.primaryButtonShadow};
 `;

--- a/website/lib/context/ExtensionData/ExtensionDataContext.ts
+++ b/website/lib/context/ExtensionData/ExtensionDataContext.ts
@@ -6,6 +6,7 @@ export interface ExtensionDataContextType {
   coopJobsListPageRows: JobsPageRowData[];
   fulltimeJobsListPageRows: JobsPageRowData[];
   extensionData: { [key: string]: string };
+  fetchExtensionData: () => void;
 }
 
 export const ExtensionDataContext = createContext<

--- a/website/lib/context/ExtensionData/ExtensionDataProvider.tsx
+++ b/website/lib/context/ExtensionData/ExtensionDataProvider.tsx
@@ -15,6 +15,7 @@ export const ExtensionDataProvider = ({ children }: IJobsTagsProvider) => {
     coopJobsListPageRows,
     fulltimeJobsListPageRows,
     extensionData,
+    fetchExtensionData,
   } = useExtensionData();
 
   const value: ExtensionDataContextType = {
@@ -22,6 +23,7 @@ export const ExtensionDataProvider = ({ children }: IJobsTagsProvider) => {
     coopJobsListPageRows,
     fulltimeJobsListPageRows,
     extensionData,
+    fetchExtensionData,
   };
 
   return (

--- a/website/lib/extension/hooks/useExtensionData.ts
+++ b/website/lib/extension/hooks/useExtensionData.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useMemo } from "react";
 import {
   buildCoopJobsListFromExtensionData,
   buildFulltimeJobsListFromExtensionData,
@@ -21,8 +21,11 @@ export const useExtensionData = () => {
     [extensionData]
   );
 
-  useEffect(() => {
-    const listener = sendMessageOnLoadAndSetupListenerHook(
+  const fetchExtensionData = () => {
+    if (isDataReady) {
+      return;
+    }
+    sendMessageOnLoadAndSetupListenerHook(
       {
         id: ListenerId.allExtensionLocalStorage,
         reqName: RequestName.getLocal,
@@ -40,18 +43,13 @@ export const useExtensionData = () => {
         }
       }
     );
-
-    return () => {
-      // Clean up the listener if necessary
-      // For example, if sendMessageOnLoadAndSetupListenerHook returns a function to remove the listener
-      listener();
-    };
-  }, []);
+  };
 
   return {
     isDataReady,
     coopJobsListPageRows,
     fulltimeJobsListPageRows,
     extensionData,
+    fetchExtensionData,
   };
 };

--- a/website/lib/hooks/useEditTagModal.ts
+++ b/website/lib/hooks/useEditTagModal.ts
@@ -33,6 +33,7 @@ export const useEditTagModal = () => {
     } catch (e) {
       console.log(e);
     }
+    setDeleteMode(false);
     setIsLoading(false);
   };
   const handleDeleteTag = async () => {
@@ -42,6 +43,7 @@ export const useEditTagModal = () => {
     } catch (e) {
       console.log(e);
     }
+    setDeleteMode(false);
     setIsLoading(false);
   };
 
@@ -55,9 +57,13 @@ export const useEditTagModal = () => {
 
   const isOpen = !!editTag;
 
+  const onClose = () => {
+    closeEditModal();
+    setDeleteMode(false);
+  };
   return {
     initTag: editTag,
-    onClose: closeEditModal,
+    onClose,
     deleteMode,
     setDeleteMode,
     setTag,

--- a/website/lib/hooks/useJobPage.ts
+++ b/website/lib/hooks/useJobPage.ts
@@ -19,7 +19,8 @@ type CompanyCard = {
 };
 
 export const useJobPage = (jobID?: string) => {
-  const { extensionData: jobs } = useExtensionsDataContext();
+  const { extensionData: jobs, fetchExtensionData } =
+    useExtensionsDataContext();
   const [tabSelected, setTabSelected] = useState(0);
   const [companyURL, setCompanyURL] = useState<string | undefined>(undefined);
   const [imageURL, setImageURL] = useState<string>("");
@@ -61,7 +62,9 @@ export const useJobPage = (jobID?: string) => {
     country: job?.country ?? "",
     positionTitle: job?.jobName ?? "",
   };
-
+  useEffect(() => {
+    fetchExtensionData();
+  }, []);
   useEffect(() => {
     if (jobInfo.length === 0 || !companyInfo.companyName || init) {
       return;

--- a/website/lib/hooks/useJobsList.ts
+++ b/website/lib/hooks/useJobsList.ts
@@ -18,7 +18,11 @@ export const useJobsList = () => {
     coopJobsListPageRows: jobs,
     extensionData,
     isDataReady,
+    fetchExtensionData,
   } = useExtensionsDataContext();
+  useEffect(() => {
+    fetchExtensionData();
+  }, []);
   // Search and job states
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   const [searchIndex, setSearchIndex] = useState(lunr(() => {}));

--- a/website/pages/setup/index.tsx
+++ b/website/pages/setup/index.tsx
@@ -9,6 +9,7 @@ import { LocalStorageMetadataKeys } from "src/lib/extension/shared/userProfile";
 import { useExtensionsDataContext } from "src/lib/context/ExtensionData/ExtensionDataContext";
 import Link from "next/link";
 import { PageWrapper } from "src/components/PageWrapper/PageWrapper";
+import { useEffect } from "react";
 
 const Step2 = () => {
   return (
@@ -73,7 +74,11 @@ const Step4 = () => {
 };
 
 const Setup = () => {
-  const { extensionData, isDataReady } = useExtensionsDataContext();
+  const { extensionData, isDataReady, fetchExtensionData } =
+    useExtensionsDataContext();
+  useEffect(() => {
+    fetchExtensionData();
+  }, []);
   let step = 1;
   if (isDataReady) {
     step = 2;


### PR DESCRIPTION
- Now we only fetch the extension data when we need it, should make some pages smoother
- Deleting and tag or exiting the edit tag menu now closes the "delete" verification
- Fixed jobs on jobs list page opening in the same window (should open new)